### PR TITLE
Call django.setup() explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Tryout django orm and fastapi for API
 
 - run FastAPI
     ```commandline
-    poetry run uvicorn mysite.asgi:fastapp --port 8001 --reload
+    poetry run uvicorn mysite.asgi:application --port 8001 --reload
     ```
   
 - run django for convenience

--- a/mysite/asgi.py
+++ b/mysite/asgi.py
@@ -9,12 +9,12 @@ https://docs.djangoproject.com/en/3.2/howto/deployment/asgi/
 
 import os
 
-from django.core.asgi import get_asgi_application
+import django
 from fastapi import FastAPI
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'mysite.settings')
 
-application = get_asgi_application()
+django.setup(set_prefix=False)
 
 from poll.routers import books_router  # noqa: E402
 

--- a/mysite/asgi.py
+++ b/mysite/asgi.py
@@ -18,5 +18,5 @@ django.setup(set_prefix=False)
 
 from poll.routers import books_router  # noqa: E402
 
-fastapp = FastAPI()
-fastapp.include_router(books_router, tags=["books"], prefix="/api/books")
+application = FastAPI()
+application.include_router(books_router, tags=["books"], prefix="/api/books")

--- a/poll/tests/test_api.py
+++ b/poll/tests/test_api.py
@@ -1,10 +1,10 @@
 import pytest
 from fastapi.testclient import TestClient
 
-from mysite.asgi import fastapp
+from mysite.asgi import application
 from poll.models import Book
 
-client = TestClient(fastapp)
+client = TestClient(application)
 
 
 @pytest.fixture


### PR DESCRIPTION
It was called as a side-effect of
`django.core.asgi.get_asgi_application`, where the result
(`application`) was not used.